### PR TITLE
Add support for more versions of node

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,18 +21,17 @@ jobs:
       - name: Login to registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - run: "echo 'Building: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}'"
+      - run: "echo 'Building: ticto/node-softhsmv2:${{ matrix.NODE_VERSION }}'"
 
       - name: Build and push
         id: docker_build_server
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}
+          tags: ticto/node-softhsmv2:${{ matrix.NODE_VERSION }}
           build-args: |
             NODE_VERSION=${{ matrix.NODE_VERSION }}
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ jobs:
   docker-build-push:
     strategy:
       matrix:
-        NODE_VERSION: [10.17.0, 12, 14, 16]
+        NODE_VERSION: [10.15.3, 10.17.0, 12, 14, 16]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: "echo 'Building: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}'"
 
-      - name: Build and push featurecreep-server:latest
+      - name: Build and push
         id: docker_build_server
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ name: docker
 
 on:
   push:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   docker-build-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: docker
+
+on:
+  push:
+
+jobs:
+  docker-build-push:
+    strategy:
+      matrix:
+        NODE_VERSION: [10.17.0, 12, 14, 16]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push featurecreep-server:latest
+        id: docker_build_server
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
+          tags: ghcr.io/${{ github.event.repository.name }}:latest
+          build-args: |
+            NODE_VERSION="${{ matrix.NODE_VERSION }}"
+      - name: Image digest
+        run: echo ${{ steps.docker_build_server.outputs.digest }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
   docker-build-push:
     strategy:
       matrix:
-        NODE_VERSION: [10.15.3, 10.17.0, 12, 14, 16]
+        NODE_VERSION: [10, 12, 14, 16]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,12 +23,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: "echo 'Building: ghcr.io/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}'"
+
       - name: Build and push featurecreep-server:latest
         id: docker_build_server
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
-          tags: ghcr.io/${{ github.event.repository.name }}:latest
+          tags: ghcr.io/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}
           build-args: |
             NODE_VERSION=${{ matrix.NODE_VERSION }}
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,14 +23,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: "echo 'Building: ghcr.io/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}'"
+      - run: "echo 'Building: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}'"
 
       - name: Build and push featurecreep-server:latest
         id: docker_build_server
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
-          tags: ghcr.io/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ matrix.NODE_VERSION }}
           build-args: |
             NODE_VERSION=${{ matrix.NODE_VERSION }}
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
           tags: ghcr.io/${{ github.event.repository.name }}:latest
           build-args: |
-            NODE_VERSION="${{ matrix.NODE_VERSION }}"
+            NODE_VERSION=${{ matrix.NODE_VERSION }}
       - name: Image digest
         run: echo ${{ steps.docker_build_server.outputs.digest }}
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Building blocks:
 ## Building the image
 
 ```
-NODE_VERSION=10.16.0 && docker build -t ticto/node-softhsmv2:${NODE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} .
+export NODE_VERSION=16
+docker build -t ticto/node-softhsmv2:${NODE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} .
 ```
 
-## Performance Testing


### PR DESCRIPTION
- Build for node versions [10.15.3, 10.17.0, 12, 14, 16]
- Add a scheduled workflow to make sure the images get security fixes
- Pushes to Github container registry right now, because it was easiest to setup. If someone can set secrets in this repo (to login to Dockerhub instead of GHCR), we can push to the Dockerhub repo instead